### PR TITLE
Fix Safari Icon Bug

### DIFF
--- a/src/Body/Body.css
+++ b/src/Body/Body.css
@@ -308,7 +308,8 @@
   }
 
  .icons img:hover {
-     width: 150%;
+     transform: scale(1.5, 1.5);
+     transition: 0.5s;
  }
 
  .organ {


### PR DESCRIPTION
I'm using a different property (scale) for enlarging icons. Tested it on Safari and seems to be working fine.
Also, used a transition effect, let me know what you think! 

Closes #165 