### PR TITLE
feature/861 : Automatically pop up survey on clicking close the first…

### DIFF
--- a/src/Body/anatomicalView.js
+++ b/src/Body/anatomicalView.js
@@ -96,7 +96,16 @@ class Anatomy extends React.Component {
     };
   }
 
-  toggleModal = () => {
+  toggleModal = () =>
+  {
+    if (sessionStorage.getItem('firstVisit') != 'true')
+    {
+      sessionStorage.setItem('firstVisit', 'true');
+      const finalLink = this.state.language == "french"
+        ? "https://forms.gle/uJApr8qousrgEboX6"
+        : "https://forms.gle/nzRAFRCTNo62T4fh6";
+        window.open(finalLink, "_blank");
+    }
     this.setState({
       isOpen: !this.state.isOpen,
     });

--- a/src/LandingPage_EN.js
+++ b/src/LandingPage_EN.js
@@ -29,6 +29,7 @@ class LandingPageEN extends React.Component {
   }
   handleChange() {
     this.setState({ language: "english" })
+    sessionStorage.setItem('firstVisit', 'false');
     localStorage.setItem("app_language", this.state.language);
   }
   handleChange2() {

--- a/src/Topics/Topics.js
+++ b/src/Topics/Topics.js
@@ -23,7 +23,16 @@ class Topics extends React.Component {
     }
     this.pageViewStateUpdater = this.pageViewStateUpdater.bind(this);
   }
-  toggleModal = () => {
+  toggleModal = () =>
+  {
+    if (sessionStorage.getItem('firstVisit') != 'true')
+    {
+      sessionStorage.setItem('firstVisit', 'true');
+      const finalLink = this.state.language == "french"
+        ? "https://forms.gle/uJApr8qousrgEboX6"
+        : "https://forms.gle/nzRAFRCTNo62T4fh6";
+        window.open(finalLink, "_blank");
+    }
     this.setState({
       isOpen: !this.state.isOpen
     });


### PR DESCRIPTION
This PR is the short term solution implemented which is discussed in #861 i.e


Short-term fix: When we click "close" or "x" on a content pop-up window, automatically launch the feedback link in a new browser tab. This happens only the first time they hit "close" or "x."